### PR TITLE
feat: create action to deploy-mfe-s3

### DIFF
--- a/.github/workflows/deploy-mfe-s3.yml
+++ b/.github/workflows/deploy-mfe-s3.yml
@@ -1,0 +1,102 @@
+name: MFE S3 Bucket Deployment 🚀
+
+on:
+  push:
+    branches:
+      - ednx-release/mango.nelp
+      - ednx-rc/mango.nelp
+      
+  pull_request:
+    branches:
+       - "**ednx-rc**"
+jobs:
+  build:
+    environment: 
+      name: ${{ github.ref_name == 'ednx-release/mango.nelp' && 'prod' || 'stage' }}
+    runs-on: ubuntu-latest
+    steps:
+    
+    - name: "Echo job  vars"
+      env:
+        JOB_VARS: ${{ toJson(vars) }}
+      run: echo "$JOB_VARS"  
+  
+    - name: checkout mfe repo
+      uses: actions/checkout@v3
+       
+    - name: Use Node.js ${{ vars.NODE_VERSION }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ vars.NODE_VERSION }}
+        
+    - name: Cache node modules
+      id: cache-npm
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      name: List the state of node modules
+      continue-on-error: true
+      run: npm list
+  
+    - name: npm Install
+      run: npm install
+          
+    - name: npm Build  # check env variables of repo.
+      run: npm run build
+      env:
+        PUBLIC_PATH_CDN: ${{ vars.PUBLIC_PATH_CDN }}
+        PUBLIC_PATH: ${{ vars.PUBLIC_PATH }}
+        APP_ID: ${{ vars.APP_ID }}
+        MFE_CONFIG_API_URL: ${{ vars.MFE_CONFIG_API_URL }}
+        ENABLE_NEW_RELIC: false
+        NODE_ENV: production
+        
+    - name: print generated html of mfe
+      run: cat dist/index.html
+      
+    - name: Share artifact inside workflow
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ vars.APP_ID }}-dist-artifact
+        path: dist
+
+  deployment:
+    environment: 
+      name: ${{ github.ref_name == 'ednx-release/mango.nelp' && 'prod' || 'stage' }}
+      url: ${{ vars.PUBLIC_PATH_CDN }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # get build artifact
+      - name: Get artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.APP_ID }}-dist-artifact
+          
+      - name: "Echo job  vars"
+        env:
+          JOB_VARS: ${{ toJson(vars) }}
+        run: echo "$JOB_VARS"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Deploy to S3
+        run: |
+          aws s3 sync . $S3_BUCKET
+        env:
+          S3_BUCKET: s3://${{ vars.BUCKET_NAME }}${{ vars.PUBLIC_PATH }} --delete


### PR DESCRIPTION
# Description
This add action is tested in this repo.
https://github.com/johanv26/frontend-app-learning/blob/jlc/ednx-rc/.github/workflows/deploy-s3.yml

The flow is that I have created 2 environments: stage and prod.
It depend of the action triggered by the branch will use stage or prod enviroment.
Each environment has it related configuration of vars.

![image](https://github.com/nelc/frontend-app-learning/assets/51926076/fc18adc8-c50d-4200-861d-2a9193405f0d)
