### PR TITLE
feat: invalidate past cache for deployments

### DIFF
--- a/.github/workflows/deploy-mfe-s3.yml
+++ b/.github/workflows/deploy-mfe-s3.yml
@@ -5,30 +5,30 @@ on:
     branches:
       - ednx-release/mango.nelp
       - ednx-rc/mango.nelp
-      
+
   pull_request:
     branches:
        - "**ednx-rc**"
 jobs:
   build:
-    environment: 
+    environment:
       name: ${{ github.ref_name == 'ednx-release/mango.nelp' && 'prod' || 'stage' }}
     runs-on: ubuntu-latest
     steps:
-    
+
     - name: "Echo job  vars"
       env:
         JOB_VARS: ${{ toJson(vars) }}
-      run: echo "$JOB_VARS"  
-  
+      run: echo "$JOB_VARS"
+
     - name: checkout mfe repo
       uses: actions/checkout@v3
-       
+
     - name: Use Node.js ${{ vars.NODE_VERSION }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ vars.NODE_VERSION }}
-        
+
     - name: Cache node modules
       id: cache-npm
       uses: actions/cache@v3
@@ -47,10 +47,10 @@ jobs:
       name: List the state of node modules
       continue-on-error: true
       run: npm list
-  
+
     - name: npm Install
       run: npm install
-          
+
     - name: npm Build  # check env variables of repo.
       run: npm run build
       env:
@@ -60,10 +60,10 @@ jobs:
         MFE_CONFIG_API_URL: ${{ vars.MFE_CONFIG_API_URL }}
         ENABLE_NEW_RELIC: false
         NODE_ENV: production
-        
+
     - name: print generated html of mfe
       run: cat dist/index.html
-      
+
     - name: Share artifact inside workflow
       uses: actions/upload-artifact@v3
       with:
@@ -71,7 +71,7 @@ jobs:
         path: dist
 
   deployment:
-    environment: 
+    environment:
       name: ${{ github.ref_name == 'ednx-release/mango.nelp' && 'prod' || 'stage' }}
       url: ${{ vars.PUBLIC_PATH_CDN }}
     runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ vars.APP_ID }}-dist-artifact
-          
+
       - name: "Echo job  vars"
         env:
           JOB_VARS: ${{ toJson(vars) }}
@@ -100,3 +100,7 @@ jobs:
           aws s3 sync . $S3_BUCKET
         env:
           S3_BUCKET: s3://${{ vars.BUCKET_NAME }}${{ vars.PUBLIC_PATH }} --delete
+
+      - name: Invalidate past cloudfront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
# Description
This add an invalidation for cache in each environment when the action is triggered.

## test
testes in stage
![2023-07-14_14-31](https://github.com/nelc/frontend-app-learning/assets/51926076/1f15ed15-b366-45bd-8635-fe074c5c8b36)
![2023-07-14_14-32](https://github.com/nelc/frontend-app-learning/assets/51926076/28e3b596-1e05-4137-8d6e-fda76f1dbd96)

## extra info
The id was set in the repo secrets.
![Screenshot from 2023-07-14 14-23-02](https://github.com/nelc/frontend-app-learning/assets/51926076/5bd64a2f-3647-4f42-b5d2-89dfec3ae2c8)
