### PR TITLE
fix: this checks that the course has an end date before rendering cer…

### DIFF
--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -179,7 +179,7 @@ const CertificateStatus = ({ intl }) => {
       default:
         // if user completes a course before certificates are available, treat it as notAvailable
         // regardless of passing or nonpassing status
-        if (!canViewCertificate) {
+        if (!canViewCertificate && end) {
           certCase = 'notAvailable';
           endDate = intl.formatDate(end, {
             year: 'numeric',


### PR DESCRIPTION
## Description
This just checks the course end date before rendering the certificate message, if the course doesn't have end date this won't render anything instead of showing the message with the old date 

## Before
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/a60d9e66-9b45-41f2-91c8-c52455a0715d)


## After
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/f742aa71-7993-4197-9556-40231fd88627)

