### PR TITLE
fix: deactivate fail on upload coverage failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
## Description
Disable failure on codecov fail

Cherry pick of https://github.com/nelc/frontend-app-learning/commit/cd0417c876057bf4719b2da64c0599e4ec13215b