### PR TITLE
And/add report button

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -13,7 +13,7 @@ import { useSelector } from 'react-redux';
 import { history } from '@edx/frontend-platform';
 import SequenceExamWrapper from '@edx/frontend-lib-special-exams';
 import { breakpoints, useWindowSize } from '@edx/paragon';
-import { LikeDislikeUnit } from '@edunext/frontend-essentials';
+import { ReportButton, LikeDislikeUnit } from '@edunext/frontend-essentials';
 
 import PageLoading from '../../../generic/PageLoading';
 import { useModel } from '../../../generic/model-store';
@@ -179,6 +179,7 @@ const Sequence = ({
             <>
               <div className="nelp-container">
                 <LikeDislikeUnit courseId={courseId} unitId={unitId} />
+                <ReportButton courseId={courseId} unitId={unitId} />
               </div>
 
               <UnitNavigation

--- a/src/courseware/course/sequence/Sequence.scss
+++ b/src/courseware/course/sequence/Sequence.scss
@@ -1,0 +1,5 @@
+.nelp-container {
+	display: flex;
+	text-align: center;
+    justify-content: center;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -381,3 +381,4 @@
 @import "course-home/progress-tab/grades/course-grade/GradeBar.scss";
 @import "courseware/course/course-exit/CourseRecommendations";
 @import "product-tours/newUserCourseHomeTour/NewUserCourseHomeTourModal.scss";
+@import "courseware/course/sequence/Sequence.scss";


### PR DESCRIPTION
## Description
This is a cherry pick of  https://github.com/nelc/frontend-app-learning/commit/7426b753bdceb87f2eaa8c342ca9340afc29947e  and basically this adds the report frontend-essentials component


## How To test
1. Add to your platform settings `MFE_CONFIG["COURSE_EXPERIENCE_API_URL"] = "http://local.overhang.io:8000/eox-nelp/api/experience/v1"`
2. Go to a unit
3. press report
4. select an option and press save
5. check the admin panel `/admin/eox_nelp/reportunit`

## Result

https://github.com/nelc/frontend-app-learning/assets/36200299/80ca2209-00d4-49e3-b03d-7c9bf926c84d

