### PR TITLE
And/add deployment action

### DIFF
--- a/.github/workflows/deploy-mfe-s3.yml
+++ b/.github/workflows/deploy-mfe-s3.yml
@@ -1,0 +1,107 @@
+name: MFE S3 Bucket Deployment 🚀
+
+env:
+  RELEASE_VERSION: unset ## Set this variable in your branch to activate the production deployments.
+
+on:
+  push:
+    branches:
+      - unset ## Specify the branches that should trigger this action.
+
+  pull_request:
+    branches:
+       - "**open-rc**"
+jobs:
+  build:
+    environment:
+      name: ${{ github.ref_name == 'open-release/${{ env.RELEASE_VERSION }}.nelp' && 'prod' || 'stage' }}
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Echo job  vars"
+      env:
+        JOB_VARS: ${{ toJson(vars) }}
+      run: echo "$JOB_VARS"
+
+    - name: checkout mfe repo
+      uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ vars.NODE_VERSION }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ vars.NODE_VERSION }}
+
+    - name: Cache node modules
+      id: cache-npm
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      name: List the state of node modules
+      continue-on-error: true
+      run: npm list
+
+    - name: npm Install
+      run: npm install
+
+    - name: npm Build  # check env variables of repo.
+      run: npm run build
+      env:
+        PUBLIC_PATH: ${{ vars.PUBLIC_PATH_CDN }}
+        APP_ID: ${{ vars.APP_ID }}
+        MFE_CONFIG_API_URL: ${{ vars.MFE_CONFIG_API_URL }}
+        ENABLE_NEW_RELIC: false
+        NODE_ENV: production
+
+    - name: print generated html of mfe
+      run: cat dist/index.html
+
+    - name: Share artifact inside workflow
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ vars.APP_ID }}-dist-artifact
+        path: dist
+
+  deployment:
+    environment:
+      name: ${{ github.ref_name == 'open-release/${{ env.RELEASE_VERSION }}.nelp' && 'prod' || 'stage' }}
+      url: ${{ vars.PUBLIC_PATH_CDN }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # get build artifact
+      - name: Get artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ vars.APP_ID }}-dist-artifact
+
+      - name: "Echo job  vars"
+        env:
+          JOB_VARS: ${{ toJson(vars) }}
+        run: echo "$JOB_VARS"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Deploy to S3
+        run: |
+          aws s3 sync . $S3_BUCKET --delete
+        env:
+          S3_BUCKET: s3://${{ vars.BUCKET_NAME }}/${{ vars.APP_ID }}/
+
+      - name: Invalidate past cloudfront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
## Description

These changes were included in this [pr](https://github.com/nelc/frontend-app-learning/pull/23) however that didn't work so this version includes a new commit that removes the RELEASE_VERSION variable from the workflow level 

Based on [this](https://stackoverflow.com/questions/74298387/github-actions-env-value-in-branches-names-i-e-on-push) that is not possible 

There is a test [pr](https://github.com/nelc/frontend-app-learning/pull/25) against the rc branch that worked 