### PR TITLE
fix: update section icons

### DIFF
--- a/src/course-home/outline-tab/Section.jsx
+++ b/src/course-home/outline-tab/Section.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Collapsible, IconButton } from '@edx/paragon';
-import { faCheckCircle as fasCheckCircle, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle as fasCheckCircle } from '@fortawesome/free-solid-svg-icons';
+import { Minus, Plus } from '@edx/paragon/icons';
 import { faCheckCircle as farCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -82,7 +83,7 @@ const Section = ({
         iconWhenClosed={(
           <IconButton
             alt={intl.formatMessage(messages.openSection)}
-            icon={faPlus}
+            iconAs={Plus}
             onClick={() => { setOpen(true); }}
             size="sm"
           />
@@ -90,7 +91,7 @@ const Section = ({
         iconWhenOpen={(
           <IconButton
             alt={intl.formatMessage(genericMessages.close)}
-            icon={faMinus}
+            iconAs={Minus}
             onClick={() => { setOpen(false); }}
             size="sm"
           />


### PR DESCRIPTION
## Description

FontAwesomeIcon was deprecated in this [pr ](https://github.com/openedx/paragon/pull/2327/files) so this updates the icon components

## Before
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/d7ac72a3-2db2-4ed9-b47d-1211376f10f1)
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/cfa3437e-0ce5-4cea-8d73-80a000fc07dc)


## After
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/b3e48bd8-86dc-4563-acc6-8c8843d6e014)
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/57b64e7d-f722-49ce-b3e2-f6c4d7806500)
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/5df76a74-fb25-4afe-b59e-bcd4a36bd46c)
![image](https://github.com/nelc/frontend-app-learning/assets/36200299/1c21b98b-94a7-4cf4-9b64-a47a87bebf46)
