### PR TITLE
chore: update brand openedx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2402,7 +2402,7 @@
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
       "version": "1.0.0-semantically-released",
-      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#e1c115cdfe6459c322ec9fd1c31fdf33e1b7e92f",
+      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#acb7ee817e10863debc76b3ae988e0206e4301ac",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {


### PR DESCRIPTION
## Description
This updates the package-lock.json file to utilize the latest version of brand-openedx. It is noted that the package.json includes the reference to 'github:nelc/brand-openedx#open-release/palm.nelp'. However, the package-lock.json uses a hash to resolve the dependency, which necessitates this update.

![image](https://github.com/nelc/frontend-app-learning/assets/36200299/867e89f5-2d7c-45ec-9a28-8cc0e509f9c0)
