### PR TITLE
feat: add frontend-essentials translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ pull_translations:
 	           translations/frontend-component-header/src/i18n/messages:frontend-component-header \
 	           translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	           translations/frontend-lib-special-exams/src/i18n/messages:frontend-lib-special-exams \
-	           translations/frontend-app-learning/src/i18n/messages:frontend-app-learning
+	           translations/frontend-app-learning/src/i18n/messages:frontend-app-learning \
+	           translations/frontend-essentials/src/i18n/messages:frontend-essentials
 
-	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-lib-special-exams frontend-app-learning
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-lib-special-exams frontend-app-learning frontend-essentials
 
 
 # This target is used by Travis.


### PR DESCRIPTION
## Description
This add the frontend-essentials package to the pull_translation workflow

## Before
![image](https://github.com/user-attachments/assets/d74027a8-2f19-4854-a41a-95398efc8636)

## After
![image](https://github.com/user-attachments/assets/b70a22d4-2ae0-4792-826f-088c980f1da3)

## Note 

This depends on this [branch](https://github.com/nelc/futurex-translations/tree/and/add_essentials_translations), the revision value from the local variable `ATLAS_OPTIONS` has been change to `and/add_essentials_translations` (temporary)