### PR TITLE
fix: update default ref name

### DIFF
--- a/.github/workflows/deploy-mfe-s3.yml
+++ b/.github/workflows/deploy-mfe-s3.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to deploy to (stage or prod)'
+        description: 'Environment to deploy:'
         required: true
         default: 'stage'
         type: choice
@@ -31,7 +31,7 @@ on:
 
 jobs:
   deployment:
-    if: github.ref == github.event.repository.default_branch || inputs.environment == 'stage'
+    if: github.ref_name == github.event.repository.default_branch || inputs.environment == 'stage'
     uses: nelc/actions-hub/.github/workflows/mfe-s3-bucket-deployment.yml@main
     with:
       ENVIRONMENT: ${{ inputs.environment }}


### PR DESCRIPTION
## Description
This pull request includes minor changes to the GitHub Actions workflow configuration file `.github/workflows/deploy-mfe-s3.yml`. The changes update the environment description and modify the condition for the deployment job.

Changes to GitHub Actions workflow configuration:

* Updated the environment description to be more concise.
* Changed the condition for the deployment job to use `github.ref_name` instead of `github.ref`.