### PR TITLE
feat: update frontend-component-header and frontend-essentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edunext/frontend-essentials": "^4.4.0",
+        "@edunext/frontend-essentials": "^4.7.0",
         "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
         "@edx/frontend-component-footer": "npm:@edunext/frontend-component-footer@13.0.4-alpha.1",
-        "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.7",
+        "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.12",
         "@edx/frontend-lib-learning-assistant": "npm:@edunext/frontend-lib-learning-assistant@2.0.0-alpha.1",
         "@edx/frontend-lib-special-exams": "npm:@edunext/frontend-lib-special-exams@3.0.1-alpha.1",
         "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@edunext/frontend-essentials": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-essentials/-/frontend-essentials-4.4.0.tgz",
-      "integrity": "sha512-nj0zoNW/B6h/ekCLrvMvK/2dLbvbars11FH2bnCqjFcKIUIr2D7cnpKBylFiP1GhphGE+1bS4gYImczWp9eMMA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-essentials/-/frontend-essentials-4.7.0.tgz",
+      "integrity": "sha512-6p8cDVy3mnHDGpHn1xAyht4Q7kHEpUbASsl1AttICrOjKzJYLWmO0N5DHlEf1GK5aay7DOWD/4piu2S5lWYFsw==",
       "dependencies": {
         "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
         "@emotion/react": "^11.11.0",
@@ -2307,11 +2307,11 @@
     },
     "node_modules/@edx/frontend-component-header": {
       "name": "@edunext/frontend-component-header",
-      "version": "5.0.2-alpha.1-nelp.7",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-component-header/-/frontend-component-header-5.0.2-alpha.1-nelp.7.tgz",
-      "integrity": "sha512-JJhM9kYb6/V+KQx06p9TmIiE6XpHCvJa1e+uxsdSbbVU8G0UH7pJB4AR1zdQFc16GDcrnfDba5VLxtV7ij7AHA==",
+      "version": "5.0.2-alpha.1-nelp.12",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-component-header/-/frontend-component-header-5.0.2-alpha.1-nelp.12.tgz",
+      "integrity": "sha512-8KlE17e1ZGJHq2RbebXrGNUi9EPbAw4BAEqfduYTsWZ45K8FlipClA+D4oBdN5DqlNh0PObCcJpG7/3+YbkAjw==",
       "dependencies": {
-        "@edunext/frontend-essentials": "^4.3.0",
+        "@edunext/frontend-essentials": "^4.7.0",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
         "@fortawesome/free-regular-svg-icons": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "url": "https://github.com/openedx/frontend-app-learning/issues"
   },
   "dependencies": {
-    "@edunext/frontend-essentials": "^4.4.0",
+    "@edunext/frontend-essentials": "^4.7.0",
     "@edx/brand": "github:nelc/brand-openedx#open-release/redwood.nelp",
     "@edx/frontend-component-footer": "npm:@edunext/frontend-component-footer@13.0.4-alpha.1",
-    "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.7",
+    "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1-nelp.12",
     "@edx/frontend-lib-learning-assistant": "npm:@edunext/frontend-lib-learning-assistant@2.0.0-alpha.1",
     "@edx/frontend-lib-special-exams": "npm:@edunext/frontend-lib-special-exams@3.0.1-alpha.1",
     "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",


### PR DESCRIPTION
### Description

Update frontend-component-header to 5.0.2-alpha.1-nelp.12 and frontend-essentials to 4.7.0 the testing instructions are the same as this [pr](https://github.com/nelc/frontend-essentials/pull/70)

### Before
<img width="1772" height="909" alt="image" src="https://github.com/user-attachments/assets/a8c335aa-95d4-4ed4-9eb8-acef5cab27a6" />

### After

<img width="1597" height="917" alt="image" src="https://github.com/user-attachments/assets/2dc7ecd3-e00b-496b-ac62-c220645106ce" />
