### PR TITLE
fix: deactivate fail on upload coverage failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v5
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description
Disable failure on codecov fail
[issue](https://edunext.atlassian.net/browse/FUTUREX-1285)

Migration pr of https://github.com/nelc/frontend-app-learning/pull/34