### PR TITLE
feat: add deploy MFE to SS3 action

### DIFF
--- a/.github/workflows/deploy-mfe-s3.yml
+++ b/.github/workflows/deploy-mfe-s3.yml
@@ -1,0 +1,64 @@
+# This workflow deploys a Micro Frontend (MFE) application to an AWS S3 bucket
+#
+# Purpose:
+# - Deploys the compiled frontend assets to an S3 bucket for hosting
+# - Uses a reusable workflow from nelc/actions-hub
+# - Can target either staging or production environments
+#
+# Trigger:
+# - Manual trigger only (workflow_dispatch)
+#
+# Inputs:
+# - environment: Choose between 'stage' (default) or 'prod' environments
+#
+# Notes:
+# - For production deployments, the workflow must be run from the production branch
+# - Stage deployments can be run from any branch
+
+name: MFE S3 Bucket Deployment 🚀
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy:'
+        required: true
+        default: 'stage'
+        type: choice
+        options:
+          - stage
+          - prod
+          - advanced
+      BUCKET_NAME:
+        description: 'S3 bucket (advanced only)'
+        required: false
+        type: string
+        default: ''
+      PUBLIC_PATH_CDN:
+        description: 'CDN path (advanced only)'
+        required: false
+        type: string
+      AWS_CLOUDFRONT_DISTRIBUTION_ID:
+        description: 'CloudFront ID (advanced only)'
+        required: false
+        type: string
+
+jobs:
+  deploy_advanced_config:
+    name: Deploy (advanced)
+    if: inputs.environment == 'advanced'
+    uses: nelc/actions-hub/.github/workflows/mfe-s3-bucket-deployment.yml@main
+    with:
+      ENVIRONMENT: ${{ inputs.environment }}
+      BUCKET_NAME: ${{ inputs.BUCKET_NAME }}
+      PUBLIC_PATH_CDN: ${{ inputs.PUBLIC_PATH_CDN }}
+      AWS_CLOUDFRONT_DISTRIBUTION_ID: ${{ inputs.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+    secrets: inherit
+
+  deploy_predefined_env:
+    name: Deploy (stage/prod)
+    if: inputs.environment != 'advanced'
+    uses: nelc/actions-hub/.github/workflows/mfe-s3-bucket-deployment.yml@main
+    with:
+      ENVIRONMENT: ${{ inputs.environment }}
+    secrets: inherit


### PR DESCRIPTION
## Description
This adds the deploy-mfe-s3 github action, taken from the redwood [file](https://github.com/nelc/frontend-app-learning/blob/open-release/redwood.nelp/.github/workflows/deploy-mfe-s3.yml)
[Issue # 1436](https://edunext.atlassian.net/browse/FUTUREX-1436)