### PR TITLE
feat: add like-dislike component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,3 +41,7 @@ config.reporters = [...(config.reporters || []), ["jest-console-group-reporter",
 }]];
 
 module.exports = config;
+
+module.exports.transformIgnorePatterns = [
+  '/node_modules/(?!(@edx|@edunext|@openedx))',
+];

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "files": [
       {
         "path": "dist/*.js",
-        "maxSize": "1450kB"
+        "maxSize": "1536kB"
       }
     ],
     "normalizeFilenames": "^.+?(\\..+?)\\.\\w+$"

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -9,6 +9,7 @@ import {
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useSelector } from 'react-redux';
 import SequenceExamWrapper from '@edx/frontend-lib-special-exams';
+import { LikeDislikeUnit } from '@edunext/frontend-essentials';
 
 import PageLoading from '@src/generic/PageLoading';
 import { useModel } from '@src/generic/model-store';
@@ -206,7 +207,14 @@ const Sequence = ({
               isEnabledOutlineSidebar={isEnabledOutlineSidebar}
               renderUnitNavigation={renderUnitNavigation}
             />
-            {unitHasLoaded && renderUnitNavigation(false)}
+            {unitHasLoaded && (
+              <>
+                <div className="nelp-container">
+                  <LikeDislikeUnit courseId={courseId} unitId={unitId} />
+                </div>
+                {renderUnitNavigation(false)}
+              </>
+            )}
           </div>
         </div>
         <NotificationsDiscussionsSidebarSlot courseId={courseId} />

--- a/src/courseware/course/sequence/Sequence.test.jsx
+++ b/src/courseware/course/sequence/Sequence.test.jsx
@@ -106,7 +106,7 @@ describe('Sequence', () => {
     waitFor(() => {
       expect(screen.queryByText('Loading locked content messaging...')).toBeInTheDocument();
       // `Previous`, `Prerequisite` and `Close Tray` buttons.
-      expect(screen.getAllByRole('button').length).toEqual(3);
+      expect(screen.getAllByRole('button').length).toEqual(5); // two more buttons like and dislike
       // `Next` button.
       expect(screen.getAllByRole('link').length).toEqual(1);
 
@@ -162,7 +162,7 @@ describe('Sequence', () => {
     waitFor(() => {
       expect(screen.findByText('Loading learning sequence...')).toBeInTheDocument();
       // `Previous`, `Prerequisite` and `Close Tray` buttons.
-      expect(screen.getAllByRole('button')).toHaveLength(3);
+      expect(screen.getAllByRole('button')).toHaveLength(5); // two more buttons like and dislike
       // Renders `Next` button.
       expect(screen.getAllByRole('link')).toHaveLength(1);
 

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -201,6 +201,9 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
     const proctoredExamApiUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/attempt/course_id/${courseMetadata.id}/content_id/${sequenceMetadata.item_id}?is_learning_mfe=true`;
     axiosMock.onGet(proctoredExamApiUrl).reply(200, { exam: {}, active_attempt: {} });
   });
+  // frontend essentials configuration, this will return an status 404 on every like-dislike request
+  const likeDislikeUrlPattern = new RegExp(`${getConfig().COURSE_EXPERIENCE_API_URL}/like/units/.*/`);
+  axiosMock.onGet(likeDislikeUrlPattern).reply(404, {});
 
   logUnhandledRequests(axiosMock);
 


### PR DESCRIPTION
### Description
Adds the like-dislike component in the Sequence file. Migration pr of https://github.com/nelc/frontend-app-learning/pull/35
Issue # [1284](https://edunext.atlassian.net/browse/FUTUREX-1284)

### How to test
1. Add to your platform settings `MFE_CONFIG["COURSE_EXPERIENCE_API_URL"] = "http://local.openedx.io:8000/eox-nelp/api/experience/v1"`
2. Go to a unit
3. press like or dislike
4. Reload and verify previous state, alternative you can check the admin panel `/admin/eox_nelp/likedislikeunit`

## Expected result
<img width="1837" height="946" alt="image" src="https://github.com/user-attachments/assets/1fbf9f7b-fce6-4284-bc54-b4ee8c5cdc83" />

