### PR TITLE
feat: add report button component

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -9,7 +9,7 @@ import {
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useSelector } from 'react-redux';
 import SequenceExamWrapper from '@edx/frontend-lib-special-exams';
-import { LikeDislikeUnit } from '@edunext/frontend-essentials';
+import { ReportButton, LikeDislikeUnit } from '@edunext/frontend-essentials';
 
 import PageLoading from '@src/generic/PageLoading';
 import { useModel } from '@src/generic/model-store';
@@ -211,6 +211,7 @@ const Sequence = ({
               <>
                 <div className="nelp-container">
                   <LikeDislikeUnit courseId={courseId} unitId={unitId} />
+                  <ReportButton courseId={courseId} unitId={unitId} />
                 </div>
                 {renderUnitNavigation(false)}
               </>

--- a/src/courseware/course/sequence/Sequence.scss
+++ b/src/courseware/course/sequence/Sequence.scss
@@ -1,0 +1,5 @@
+.nelp-container {
+  display: flex;
+  text-align: center;
+  justify-content: center;
+}

--- a/src/courseware/course/sequence/Sequence.test.jsx
+++ b/src/courseware/course/sequence/Sequence.test.jsx
@@ -106,7 +106,7 @@ describe('Sequence', () => {
     waitFor(() => {
       expect(screen.queryByText('Loading locked content messaging...')).toBeInTheDocument();
       // `Previous`, `Prerequisite` and `Close Tray` buttons.
-      expect(screen.getAllByRole('button').length).toEqual(5); // two more buttons like and dislike
+      expect(screen.getAllByRole('button').length).toEqual(6); // three more buttons like, dislike and report
       // `Next` button.
       expect(screen.getAllByRole('link').length).toEqual(1);
 
@@ -162,7 +162,7 @@ describe('Sequence', () => {
     waitFor(() => {
       expect(screen.findByText('Loading learning sequence...')).toBeInTheDocument();
       // `Previous`, `Prerequisite` and `Close Tray` buttons.
-      expect(screen.getAllByRole('button')).toHaveLength(5); // two more buttons like and dislike
+      expect(screen.getAllByRole('button')).toHaveLength(6); // three more buttons like, dislike and report
       // Renders `Next` button.
       expect(screen.getAllByRole('link')).toHaveLength(1);
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -473,3 +473,4 @@
 @import "course-tabs/course-tabs-navigation.scss";
 @import "courseware/course/sidebar/common/SidebarBase.scss";
 @import "courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss";
+@import "courseware/course/sequence/Sequence.scss";


### PR DESCRIPTION
## Description
Adds the report button  component. Migration pr of https://github.com/nelc/frontend-app-learning/pull/36
Issue # [1438](https://edunext.atlassian.net/browse/FUTUREX-1438)

## How To test
1. Add to your platform settings `MFE_CONFIG["COURSE_EXPERIENCE_API_URL"] = "http://local.openedx.io:8000/eox-nelp/api/experience/v1"`
2. Go to a unit
3. press report
4. select an option and press save
5. check the admin panel `/admin/eox_nelp/reportunit`

### Expected result
<img width="1820" height="984" alt="image" src="https://github.com/user-attachments/assets/1b56d2f5-76e9-4404-93f4-8a2aa87054af" />
