### PR TITLE
fix: this checks that the course has an end date before rendering cer…

### DIFF
--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -185,7 +185,7 @@ const CertificateStatus = () => {
       default:
         // if user completes a course before certificates are available, treat it as notAvailable
         // regardless of passing or nonpassing status
-        if (!canViewCertificate) {
+        if (!canViewCertificate && end) {
           certCase = 'notAvailable';
           endDate = intl.formatDate(end, {
             year: 'numeric',


### PR DESCRIPTION
## Description
This adds a new condition that limits the `certificate status` message based on the end date. This is a migration pr of https://github.com/nelc/frontend-app-learning/pull/39
[Issue # 1281](https://edunext.atlassian.net/browse/FUTUREX-1281)

## Before
<img width="1799" height="817" alt="image" src="https://github.com/user-attachments/assets/bef74d67-3d18-4f6b-b71c-83ad99722316" />

## After
<img width="1828" height="870" alt="image" src="https://github.com/user-attachments/assets/8b54fb9a-782c-4117-b5df-4c66b839ed4c" />

## How to test 
To replicate this issue, the response from `{lms_host}/api/course_home/progress/{course_id}` must contain `"certificate_data": null`. If your course is new, you only need to set a valid user mode, and that’s enough.

1. Ensure that your user has a valid certificate mode (e.g., honor). You can change this in the admin panel.
2. Go to your test course and then open the Progress tab.
3. Check out this branch.
4. Verify that the message has disappeared.