### PR TITLE
feat: add frontend-essentials translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ pull_translations:
 	           translations/frontend-component-header/src/i18n/messages:frontend-component-header \
 	           translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	           translations/frontend-lib-special-exams/src/i18n/messages:frontend-lib-special-exams \
-	           translations/frontend-app-learning/src/i18n/messages:frontend-app-learning
+	           translations/frontend-app-learning/src/i18n/messages:frontend-app-learning \
+	           translations/frontend-essentials/src/i18n/messages:frontend-essentials
 
-	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-lib-special-exams frontend-app-learning
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-lib-special-exams frontend-app-learning frontend-essentials
 
 
 # This target is used by Travis.


### PR DESCRIPTION
## Description
This adds the frontend-essentils package to the pull_translations workflow. migration pr of https://github.com/nelc/frontend-app-learning/pull/45

Issue # [1283](https://edunext.atlassian.net/browse/FUTUREX-1283)

## How to test
1. Checkout this branch 
2. Run the following commands

`export PATH="$(pwd)/node_modules/.bin:$PATH"`

`make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository=nelc/futurex-translations --revision=open-release/redwood.master" pull_translations`


3. Verify the translation (Like-dislike and report  button, feedback component and  profile data component )

<img width="1646" height="880" alt="image" src="https://github.com/user-attachments/assets/aecf7e4f-d2be-4a96-8089-9403cc16bd10" />

<img width="1826" height="981" alt="image" src="https://github.com/user-attachments/assets/0fa52fb3-ba1a-48c7-9f9d-911dd4b6662e" />

<img width="1821" height="992" alt="image" src="https://github.com/user-attachments/assets/a498748d-4403-46b2-9a5b-7caf3e0686c0" />

## Note 
the Arabic name and national id translation is missing the futurex-translations repo
