### PR TITLE
feat: update brand openedx and add its styles to the index.scss file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edunext/frontend-essentials": "5.0.0",
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "@edx/brand": "github:nelc/brand-openedx#open-release/teak.nelp",
         "@edx/browserslist-config": "1.5.0",
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.2.0",
@@ -2230,9 +2230,8 @@
     },
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
+      "version": "1.0.0-semantically-released",
+      "resolved": "git+ssh://git@github.com/nelc/brand-openedx.git#ae9e0a984330058859a186bb01ee1fe20fce28de",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
@@ -2468,6 +2467,12 @@
         "react-router-dom": "^6",
         "redux": "^4"
       }
+    },
+    "node_modules/@edx/frontend-lib-learning-assistant/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@edx/frontend-lib-special-exams": {
       "version": "3.5.0",
@@ -4766,6 +4771,12 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-error-boundary": "^4.0.11"
       }
+    },
+    "node_modules/@openedx/frontend-plugin-framework/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w=="
     },
     "node_modules/@openedx/frontend-plugin-framework/node_modules/core-js": {
       "version": "3.37.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@edunext/frontend-essentials": "5.0.0",
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+    "@edx/brand": "github:nelc/brand-openedx#open-release/teak.nelp",
     "@edx/browserslist-config": "1.5.0",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.2.0",

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,6 +3,9 @@
 @import "~@edx/frontend-component-footer/dist/footer";
 @import "~@edx/frontend-component-header/dist/index";
 
+@import "@edx/brand/paragon/fonts";
+@import "@edx/brand/paragon/variables";
+@import "@edx/brand/paragon/overrides";
 
 #root {
   display: flex;


### PR DESCRIPTION
## Description
This sets the NELC openedx brand version and includes its styles in the  index.scss file. Migration pr of https://github.com/nelc/frontend-app-learning/pull/42

## How to test
1. Checkout this branch
2. Run npm install
3. Verify default font

## Before
<img width="1605" height="956" alt="image" src="https://github.com/user-attachments/assets/681a908c-ca08-49d4-9c5a-7646f1f49863" />

## After
<img width="1504" height="899" alt="image" src="https://github.com/user-attachments/assets/8c2b261e-4cfd-4566-a5dc-7b69040fa121" />

Issue # [1279](https://edunext.atlassian.net/browse/FUTUREX-1279)